### PR TITLE
Fixed compile warnings when transparency patch is applied

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -5,7 +5,7 @@
  *
  * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
  */
-static char font[] = "mono:pixelsize=14:antialias=true:autohint=true";
+static char font[] = "xos4 Terminess Powerline:pixelsize=10:antialias=true";
 static int borderpx = 2;
 
 /*
@@ -82,25 +82,47 @@ static char termname[] = "st-256color";
  */
 static unsigned int tabspaces = 8;
 
+/* bg opacity */
+int alpha = 0xc8;
+
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
+        /* m3llo colours */
+        "#4f4858",  /*  0: black    */
+        "#c05c47",  /*  1: red      */
+        "#428e8e",  /*  2: green    */
+        "#e4b226",  /*  3: yellow   */
+        "#4457a3",  /*  4: blue     */
+        "#903a62",  /*  5: magenta  */
+        "#7aa1dc",  /*  6: cyan     */
+        "#c4b7c5",  /*  7: white    */
+        "#141021",  /*  8: brblack  */
+        "#c16772",  /*  9: brred    */
+        "#afda6e",  /* 10: brgreen  */
+        "#ebcf1a",  /* 11: bryellow */
+        "#4880a5",  /* 12: brblue   */
+        "#9568a1",  /* 13: brmagenta*/
+        "#abbcda",  /* 14: brcyan   */
+        "#ffeefc",  /* 15: brwhite  */
+        "black",  /* 16: bg       */
 	/* solarized dark */
-	"#073642",  /*  0: black    */
-	"#dc322f",  /*  1: red      */
-	"#859900",  /*  2: green    */
-	"#b58900",  /*  3: yellow   */
-	"#268bd2",  /*  4: blue     */
-	"#d33682",  /*  5: magenta  */
-	"#2aa198",  /*  6: cyan     */
-	"#eee8d5",  /*  7: white    */
-	"#002b36",  /*  8: brblack  */
-	"#cb4b16",  /*  9: brred    */
-	"#586e75",  /* 10: brgreen  */
-	"#657b83",  /* 11: bryellow */
-	"#839496",  /* 12: brblue   */
-	"#6c71c4",  /* 13: brmagenta*/
-	"#93a1a1",  /* 14: brcyan   */
-	"#fdf6e3",  /* 15: brwhite  */
+        //"#073642",  /*  0: black    */
+        //"#dc322f",  /*  1: red      */
+        //"#859900",  /*  2: green    */
+        //"#b58900",  /*  3: yellow   */
+        //"#268bd2",  /*  4: blue     */
+        //"#d33682",  /*  5: magenta  */
+        //"#2aa198",  /*  6: cyan     */
+        //"#eee8d5",  /*  7: white    */
+        //"#002b36",  /*  8: brblack  */
+        //"#cb4b16",  /*  9: brred    */
+        //"#586e75",  /* 10: brgreen  */
+        //"#657b83",  /* 11: bryellow */
+        //"#839496",  /* 12: brblue   */
+        //"#6c71c4",  /* 13: brmagenta*/
+        //"#93a1a1",  /* 14: brcyan   */
+        //"#fdf6e3",  /* 15: brwhite  */
+        //"black",
 };
 
 /* Terminal colors for alternate (light) palette */
@@ -122,13 +144,14 @@ static const char *altcolorname[] = {
 	"#6c71c4",  /* 13: brmagenta*/
 	"#586e75",  /* 14: brcyan   */
 	"#002b36",  /* 15: brwhite  */
+	"black",
 };
 
 /*
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-static unsigned int defaultfg = 12;
+static unsigned int defaultfg = 15;
 static unsigned int defaultbg = 8;
 static unsigned int defaultcs = 14;
 static unsigned int defaultrcs = 15;
@@ -189,7 +212,8 @@ static Shortcut shortcuts[] = {
 	{ XK_ANY_MOD,           XK_Print,       printsel,       {.i =  0} },
 	{ MODKEY|ShiftMask,     XK_Prior,       xzoom,          {.f = +1} },
 	{ MODKEY|ShiftMask,     XK_Next,        xzoom,          {.f = -1} },
-	{ MODKEY|ShiftMask,     XK_Home,        xzoomreset,     {.f =  0} },
+	{ MODKEY|ShiftMask,     XK_Home,        xtrans,         {.f = -1} },
+	{ MODKEY|ShiftMask,     XK_End,         xtrans,         {.f = +1} },
 	{ ShiftMask,            XK_Insert,      selpaste,       {.i =  0} },
 	{ MODKEY|ShiftMask,     XK_Insert,      clippaste,      {.i =  0} },
 	{ MODKEY|ShiftMask,     XK_C,           clipcopy,       {.i =  0} },

--- a/patches/transparency.diff
+++ b/patches/transparency.diff
@@ -31,7 +31,7 @@
   */
  static unsigned int defaultfg = 12;
 -static unsigned int defaultbg = 8;
-+static unsigned int defaultbg = 257;
++static unsigned int defaultbg = 255;
  static unsigned int defaultcs = 14;
  static unsigned int defaultrcs = 15;
  

--- a/st.c
+++ b/st.c
@@ -61,6 +61,7 @@ char *argv0;
 #define XK_ANY_MOD    UINT_MAX
 #define XK_NO_MOD     0
 #define XK_SWITCH_MOD (1<<13)
+#define OPAQUE 0Xff
 #define histsize 2000
 
 /* macros */
@@ -82,6 +83,8 @@ char *argv0;
 #define TIMEDIFF(t1, t2)	((t1.tv_sec-t2.tv_sec)*1000 + \
 				(t1.tv_nsec-t2.tv_nsec)/1E6)
 #define MODBIT(x, set, bit)	((set) ? ((x) |= (bit)) : ((x) &= ~(bit)))
+
+#define USE_ARGB (alpha != OPAQUE && opt_embed == NULL)
 
 #define TRUECOLOR(r,g,b)	(1 << 24 | (r) << 16 | (g) << 8 | (b))
 #define IS_TRUECOL(x)		(1 << 24 & (x))
@@ -281,6 +284,7 @@ typedef struct {
 	int w, h; /* window width and height */
 	int ch; /* char height */
 	int cw; /* char width  */
+	int depth; /*  bit depth */
 	int cyo; /* char y offset */
 	char state; /* focus, redraw, visible */
 	int cursor; /* cursor style */
@@ -355,7 +359,7 @@ static void swapcolors(const Arg *);
 static void selpaste(const Arg *);
 static void xzoom(const Arg *);
 static void xzoomabs(const Arg *);
-static void xzoomreset(const Arg *);
+static void xtrans(const Arg *);
 static void printsel(const Arg *);
 static void printscreen(const Arg *) ;
 static void iso14755(const Arg *);
@@ -3326,7 +3330,7 @@ xresize(int col, int row)
 
 	XFreePixmap(xw.dpy, xw.buf);
 	xw.buf = XCreatePixmap(xw.dpy, xw.win, xw.w, xw.h,
-			DefaultDepth(xw.dpy, xw.scr));
+			xw.depth);
 	XftDrawChange(xw.draw, xw.buf);
 	xclear(0, 0, xw.w, xw.h);
 }
@@ -3385,6 +3389,14 @@ xloadcols(void)
 			else
 				die("Could not allocate color %d\n", i);
 		}
+
+	/* set alpha value of bg color */
+	if (USE_ARGB) {
+		dc.col[defaultbg].color.alpha = (0xffff * alpha) / OPAQUE; //0xcccc;
+		dc.col[defaultbg].pixel &= 0x00111111;
+		dc.col[defaultbg].pixel |= alpha << 24; // 0xcc000000;
+	}
+
 	loaded = 1;
 }
 
@@ -3404,6 +3416,15 @@ xsetcolorname(int x, const char *name)
 	dc.col[x] = ncolor;
 
 	return 0;
+}
+void
+xtermclear(int col1, int row1, int col2, int row2) {
+	XftDrawRect(xw.draw,
+			&dc.col[IS_SET(MODE_REVERSE) ? defaultfg : defaultbg],
+			borderpx + col1 * xw.cw,
+			borderpx + row1 * xw.ch,
+			(col2-col1+1) * xw.cw,
+			(row2-row1+1) * xw.ch);
 }
 
 /*
@@ -3655,14 +3676,17 @@ xzoomabs(const Arg *arg)
 }
 
 void
-xzoomreset(const Arg *arg)
+xtrans(const Arg *arg)
 {
-	Arg larg;
-
-	if (defaultfontsize > 0) {
-		larg.f = defaultfontsize;
-		xzoomabs(&larg);
+        alpha += arg->f * 10;
+	/* set alpha value of bg color */
+	if (USE_ARGB) {
+		dc.col[defaultbg].color.alpha = (0xffff * alpha) / OPAQUE; //0xcccc;
+		dc.col[defaultbg].pixel &= 0x00111111;
+		dc.col[defaultbg].pixel |= alpha << 24; // 0xcc000000;
 	}
+	redraw();
+	xhints();
 }
 
 void
@@ -3677,7 +3701,38 @@ xinit(void)
 	if (!(xw.dpy = XOpenDisplay(NULL)))
 		die("Can't open display\n");
 	xw.scr = XDefaultScreen(xw.dpy);
-	xw.vis = XDefaultVisual(xw.dpy, xw.scr);
+	xw.depth = (USE_ARGB) ? 32: XDefaultDepth(xw.dpy, xw.scr);
+	if (! USE_ARGB)
+		xw.vis = XDefaultVisual(xw.dpy, xw.scr);
+	else {
+		XVisualInfo *vis;
+		XRenderPictFormat *fmt;
+		int nvi;
+		int i;
+
+		XVisualInfo tpl = {
+			.screen = xw.scr,
+			.depth = 32,
+			.class = TrueColor
+		};
+
+		vis = XGetVisualInfo(xw.dpy, VisualScreenMask | VisualDepthMask | VisualClassMask, &tpl, &nvi);
+		xw.vis = NULL;
+		for(i = 0; i < nvi; i ++) {
+			fmt = XRenderFindVisualFormat(xw.dpy, vis[i].visual);
+			if (fmt->type == PictTypeDirect && fmt->direct.alphaMask) {
+				xw.vis = vis[i].visual;
+				break;
+			}
+		}
+
+		XFree(vis);
+
+		if (! xw.vis) {
+			fprintf(stderr, "Couldn't find ARGB visual.\n");
+			exit(1);
+		}
+	}
 
 	/* font */
 	if (!FcInit())
@@ -3687,7 +3742,10 @@ xinit(void)
 	xloadfonts(usedfont, 0);
 
 	/* colors */
-	xw.cmap = XDefaultColormap(xw.dpy, xw.scr);
+	if (! USE_ARGB)
+		xw.cmap = XDefaultColormap(xw.dpy, xw.scr);
+	else
+		xw.cmap = XCreateColormap(xw.dpy, XRootWindow(xw.dpy, xw.scr), xw.vis, None);
 	xloadcols();
 
 	/* adjust fixed window geometry */
@@ -3710,16 +3768,17 @@ xinit(void)
 	if (!(opt_embed && (parent = strtol(opt_embed, NULL, 0))))
 		parent = XRootWindow(xw.dpy, xw.scr);
 	xw.win = XCreateWindow(xw.dpy, parent, xw.l, xw.t,
-			xw.w, xw.h, 0, XDefaultDepth(xw.dpy, xw.scr), InputOutput,
+			xw.w, xw.h, 0, xw.depth, InputOutput,
 			xw.vis, CWBackPixel | CWBorderPixel | CWBitGravity
 			| CWEventMask | CWColormap, &xw.attrs);
 
 	memset(&gcvalues, 0, sizeof(gcvalues));
 	gcvalues.graphics_exposures = False;
-	dc.gc = XCreateGC(xw.dpy, parent, GCGraphicsExposures,
+	xw.buf = XCreatePixmap(xw.dpy, xw.win, xw.w, xw.h, xw.depth);
+	dc.gc = XCreateGC(xw.dpy,
+			(USE_ARGB)? xw.buf: parent,
+			GCGraphicsExposures,
 			&gcvalues);
-	xw.buf = XCreatePixmap(xw.dpy, xw.win, xw.w, xw.h,
-			DefaultDepth(xw.dpy, xw.scr));
 	XSetForeground(xw.dpy, dc.gc, dc.col[defaultbg].pixel);
 	XFillRectangle(xw.dpy, xw.buf, dc.gc, 0, 0, xw.w, xw.h);
 


### PR DESCRIPTION
Still learning to use git. Fixed the compile warnings in the YT video, defaultbg was out of bounds of a char variable in the transparency patch. Assumed the default bg was meant to be 255, or white.