### PR TITLE
fix defaultbg value, solve sigfault

### DIFF
--- a/config.h
+++ b/config.h
@@ -114,7 +114,7 @@ static const char *colorname[] = {
  * foreground, background, cursor, reverse cursor
  */
 unsigned int defaultfg = 12;
-unsigned int defaultbg = 256;
+unsigned int defaultbg = 257;
 static unsigned int defaultcs = 14;
 static unsigned int defaultrcs = 15;
 


### PR DESCRIPTION
Looks like the value on the defaultbg=256 gives a segmentation fault

```
carlos@Sirio:~/src/st/st_LukeSmithxyz$ ./st 
*** Error in `./st': free(): invalid next size (normal): 0x00000000010d6a10 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f41962587e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f419626137a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f419626553c]
/lib/x86_64-linux-gnu/libc.so.6(_IO_setb+0x4b)[0x7f419625c54b]
/lib/x86_64-linux-gnu/libc.so.6(_IO_file_close_it+0xae)[0x7f419625a8ee]
/lib/x86_64-linux-gnu/libc.so.6(fclose+0x18f)[0x7f419624e3ef]
/usr/lib/x86_64-linux-gnu/libX11.so.6(+0x4ed2a)[0x7f4196e5ed2a]
/usr/lib/x86_64-linux-gnu/libX11.so.6(_XlcFileName+0x114)[0x7f4196e5f114]
/usr/lib/x86_64-linux-gnu/libX11.so.6(_XimCheckIfLocalProcessing+0x5e)[0x7f4196e753be]
/usr/lib/x86_64-linux-gnu/libX11.so.6(_XimOpenIM+0xe5)[0x7f4196e740d5]
./st[0x40bde5]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f4196201830]
./st[0x403499]
======= Memory map: ========
00400000-00410000 r-xp 00000000 08:11 3903098                            /home/carlos/src/st/st_LukeSmithxyz/st
00610000-00611000 r--p 00010000 08:11 3903098                            /home/carlos/src/st/st_LukeSmithxyz/st
00611000-00614000 rw-p 00011000 08:11 3903098                            /home/carlos/src/st/st_LukeSmithxyz/st
00614000-0061b000 rw-p 00000000 00:00 0 
00d8e000-010ef000 rw-p 00000000 00:00 0                                  [heap]
7f4190000000-7f4190021000 rw-p 00000000 00:00 0 
7f4190021000-7f4194000000 ---p 00000000 00:00 0 
7f41945b8000-7f41945ce000 r-xp 00000000 08:11 5244656                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f41945ce000-7f41947cd000 ---p 00016000 08:11 5244656                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f41947cd000-7f41947ce000 rw-p 00015000 08:11 5244656                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f4194814000-7f4194865000 r--p 00000000 08:11 4203547                    /usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf
7f4194865000-7f41948a3000 r--p 00000000 08:11 4195641                    /usr/share/fonts/truetype/dejavu/DejaVuSansMono-BoldOblique.ttf                                                                                                      
7f41948a3000-7f41948e1000 r--p 00000000 08:11 4195642                    /usr/share/fonts/truetype/dejavu/DejaVuSansMono-Oblique.ttf                                                                                                          
7f41948e1000-7f4194935000 r--p 00000000 08:11 4203546                    /usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf                                                                                                                  
7f4194935000-7f4194e82000 r--p 00000000 08:11 3933805                    /usr/lib/locale/locale-archive                                                                                                                                       
7f4194e82000-7f4194ea6000 r-xp 00000000 08:11 5244812                    /lib/x86_64-linux-gnu/libpng12.so.0.54.0                                                                                                                             
7f4194ea6000-7f41950a5000 ---p 00024000 08:11 5244812                    /lib/x86_64-linux-gnu/libpng12.so.0.54.0                                                                                                                             
7f41950a5000-7f41950a6000 r--p 00023000 08:11 5244812                    /lib/x86_64-linux-gnu/libpng12.so.0.54.0                                                                                                                             
7f41950a6000-7f41950a7000 rw-p 00024000 08:11 5244812                    /lib/x86_64-linux-gnu/libpng12.so.0.54.0                                                                                                                             
7f41950a7000-7f41950c0000 r-xp 00000000 08:11 5244518                    /lib/x86_64-linux-gnu/libz.so.1.2.8                                                                                                                                  
7f41950c0000-7f41952bf000 ---p 00019000 08:11 5244518                    /lib/x86_64-linux-gnu/libz.so.1.2.8                                                                                                                                  
7f41952bf000-7f41952c0000 r--p 00018000 08:11 5244518                    /lib/x86_64-linux-gnu/libz.so.1.2.8                                                                                                                                  
7f41952c0000-7f41952c1000 rw-p 00019000 08:11 5244518                    /lib/x86_64-linux-gnu/libz.so.1.2.8                                                                                                                                  
7f41952c1000-7f41952c6000 r-xp 00000000 08:11 3933222                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0                                                                                                                          
7f41952c6000-7f41954c5000 ---p 00005000 08:11 3933222                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0                                                                                                                          
7f41954c5000-7f41954c6000 r--p 00004000 08:11 3933222                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0                                                                                                                          
7f41954c6000-7f41954c7000 rw-p 00005000 08:11 3933222                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0                                                                                                                          
7f41954c7000-7f41954c9000 r-xp 00000000 08:11 3932535                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0                                                                                                                            
7f41954c9000-7f41956c9000 ---p 00002000 08:11 3932535                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0                                                                                                                            
7f41956c9000-7f41956ca000 r--p 00002000 08:11 3932535                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0                                                                                                                            
7f41956ca000-7f41956cb000 rw-p 00003000 08:11 3932535                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0                                                                                                                            
7f41956cb000-7f41956f1000 r-xp 00000000 08:11 5244731                    /lib/x86_64-linux-gnu/libexpat.so.1.6.0                                                                                                                              
7f41956f1000-7f41958f1000 ---p 00026000 08:11 5244731                    /lib/x86_64-linux-gnu/libexpat.so.1.6.0                                                                                                                              
7f41958f1000-7f41958f3000 r--p 00026000 08:11 5244731                    /lib/x86_64-linux-gnu/libexpat.so.1.6.0                                                                                                                              
7f41958f3000-7f41958f4000 rw-p 00028000 08:11 5244731                    /lib/x86_64-linux-gnu/libexpat.so.1.6.0                                                                                                                              
7f41958f4000-7f4195998000 r-xp 00000000 08:11 3933284                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.12.1                                                                                                                      
7f4195998000-7f4195b97000 ---p 000a4000 08:11 3933284                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.12.1                                                                                                                      
7f4195b97000-7f4195b9d000 r--p 000a3000 08:11 3933284                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.12.1                                                                                                                      
7f4195b9d000-7f4195b9e000 rw-p 000a9000 08:11 3933284                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.12.1
7f4195b9e000-7f4195ba1000 r-xp 00000000 08:11 5245448                    /lib/x86_64-linux-gnu/libdl-2.23.so
7f4195ba1000-7f4195da0000 ---p 00003000 08:11 5245448                    /lib/x86_64-linux-gnu/libdl-2.23.so
7f4195da0000-7f4195da1000 r--p 00002000 08:11 5245448                    /lib/x86_64-linux-gnu/libdl-2.23.so
7f4195da1000-7f4195da2000 rw-p 00003000 08:11 5245448                    /lib/x86_64-linux-gnu/libdl-2.23.so
7f4195da2000-7f4195dc3000 r-xp 00000000 08:11 3933875                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f4195dc3000-7f4195fc2000 ---p 00021000 08:11 3933875                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f4195fc2000-7f4195fc3000 r--p 00020000 08:11 3933875                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f4195fc3000-7f4195fc4000 rw-p 00021000 08:11 3933875                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f4195fc4000-7f4195fdc000 r-xp 00000000 08:11 5245445                    /lib/x86_64-linux-gnu/libpthread-2.23.so
7f4195fdc000-7f41961db000 ---p 00018000 08:11 5245445                    /lib/x86_64-linux-gnu/libpthread-2.23.so
7f41961db000-7f41961dc000 r--p 00017000 08:11 5245445                    /lib/x86_64-linux-gnu/libpthread-2.23.so
7f41961dc000-7f41961dd000 rw-p 00018000 08:11 5245445                    /lib/x86_64-linux-gnu/libpthread-2.23.so
7f41961dd000-7f41961e1000 rw-p 00000000 00:00 0 
7f41961e1000-7f41963a1000 r-xp 00000000 08:11 5245446                    /lib/x86_64-linux-gnu/libc-2.23.so
7f41963a1000-7f41965a1000 ---p 001c0000 08:11 5245446                    /lib/x86_64-linux-gnu/libc-2.23.so
7f41965a1000-7f41965a5000 r--p 001c0000 08:11 5245446                    /lib/x86_64-linux-gnu/libc-2.23.so
7f41965a5000-7f41965a7000 rw-p 001c4000 08:11 5245446                    /lib/x86_64-linux-gnu/libc-2.23.so
7f41965a7000-7f41965ab000 rw-p 00000000 00:00 0 
7f41965ab000-7f41965e8000 r-xp 00000000 08:11 3932409                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.9.0
7f41965e8000-7f41967e7000 ---p 0003d000 08:11 3932409                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.9.0
7f41967e7000-7f41967e9000 r--p 0003c000 08:11 3932409                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.9.0
7f41967e9000-7f41967ee000 rw-p 0003e000 08:11 3932409                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.9.0
7f41967ee000-7f41967f7000 r-xp 00000000 08:11 3939863                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f41967f7000-7f41969f6000 ---p 00009000 08:11 3939863                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f41969f6000-7f41969f7000 r--p 00008000 08:11 3939863                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f41969f7000-7f41969f8000 rw-p 00009000 08:11 3939863                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f41969f8000-7f4196a0c000 r-xp 00000000 08:11 3934330                    /usr/lib/x86_64-linux-gnu/libXft.so.2.3.2
7f4196a0c000-7f4196c0b000 ---p 00014000 08:11 3934330                    /usr/lib/x86_64-linux-gnu/libXft.so.2.3.2
7f4196c0b000-7f4196c0c000 r--p 00013000 08:11 3934330                    /usr/lib/x86_64-linux-gnu/libXft.so.2.3.2
7f4196c0c000-7f4196c0d000 rw-p 00014000 08:11 3934330                    /usr/lib/x86_64-linux-gnu/libXft.so.2.3.2
7f4196c0d000-7f4196c0f000 r-xp 00000000 08:11 5245453                    /lib/x86_64-linux-gnu/libutil-2.23.so
7f4196c0f000-7f4196e0e000 ---p 00002000 08:11 5245453                    /lib/x86_64-linux-gnu/libutil-2.23.so
7f4196e0e000-7f4196e0f000 r--p 00001000 08:11 5245453                    /lib/x86_64-linux-gnu/libutil-2.23.so
7f4196e0f000-7f4196e10000 rw-p 00002000 08:11 5245453                    /lib/x86_64-linux-gnu/libutil-2.23.so
7f4196e10000-7f4196f45000 r-xp 00000000 08:11 3936081                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f4196f45000-7f4197145000 ---p 00135000 08:11 3936081                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f4197145000-7f4197146000 r--p 00135000 08:11 3936081                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f4197146000-7f419714a000 rw-p 00136000 08:11 3936081                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f419714a000-7f4197151000 r-xp 00000000 08:11 5245464                    /lib/x86_64-linux-gnu/librt-2.23.so
7f4197151000-7f4197350000 ---p 00007000 08:11 5245464                    /lib/x86_64-linux-gnu/librt-2.23.so
7f4197350000-7f4197351000 r--p 00006000 08:11 5245464                    /lib/x86_64-linux-gnu/librt-2.23.so
7f4197351000-7f4197352000 rw-p 00007000 08:11 5245464                    /lib/x86_64-linux-gnu/librt-2.23.so
7f4197352000-7f419745a000 r-xp 00000000 08:11 5242959                    /lib/x86_64-linux-gnu/libm-2.23.so
7f419745a000-7f4197659000 ---p 00108000 08:11 5242959                    /lib/x86_64-linux-gnu/libm-2.23.so
7f4197659000-7f419765a000 r--p 00107000 08:11 5242959                    /lib/x86_64-linux-gnu/libm-2.23.so
7f419765a000-7f419765b000 rw-p 00108000 08:11 5242959                    /lib/x86_64-linux-gnu/libm-2.23.so
7f419765b000-7f4197681000 r-xp 00000000 08:11 5245444                    /lib/x86_64-linux-gnu/ld-2.23.so
7f41976b9000-7f41976ba000 rw-p 00000000 00:00 0 
7f41976ba000-7f41976bb000 r--s 00000000 08:11 5123873                    /var/cache/fontconfig/087e1975ba9a574b140bb1df193bf770-le64.cache-6
7f41976bb000-7f41976bc000 r--s 00000000 08:11 5123871                    /var/cache/fontconfig/a1f38dc94e7dfa27b81c63e1776de7fd-le64.cache-6
7f41976bc000-7f41976bd000 r--s 00000000 08:11 5123856                    /var/cache/fontconfig/588a141f52a60807c04143aedc63e678-le64.cache-6
7f41976bd000-7f41976c1000 r--s 00000000 08:11 5118807                    /var/cache/fontconfig/6aa41aa22e18b8fa06a12da28ea9c28b-le64.cache-6
7f41976c1000-7f41976c2000 r--s 00000000 08:11 5123693                    /var/cache/fontconfig/c05880de57d1f5e948fdfacc138775d9-le64.cache-6
7f41976c2000-7f41976cd000 r--s 00000000 08:11 5123672                    /var/cache/fontconfig/945677eb7aeaf62f1d50efc3fb3ec7d8-le64.cache-6
7f41976cd000-7f41976cf000 r--s 00000000 08:11 5123596                    /var/cache/fontconfig/99e8ed0e538f840c565b6ed5dad60d56-le64.cache-6
7f41976cf000-7f41976d5000 r--s 00000000 08:11 5123512                    /var/cache/fontconfig/2cd17615ca594fa2959ae173292e504c-le64.cache-6
7f41976d5000-7f41976d6000 r--s 00000000 08:11 5123504                    /var/cache/fontconfig/0d8c3b2ac0904cb8a57a757ad11a4a08-le64.cache-6
7f41976d6000-7f41976e1000 r--s 00000000 08:11 5121378                    /var/cache/fontconfig/6d41288fd70b0be22e8c3a91e032eec0-le64.cache-6
7f41976e1000-7f41976e5000 r--s 00000000 08:11 5123459                    /var/cache/fontconfig/de156ccd2eddbdc19d37a45b8b2aac9c-le64.cache-6
7f41976e5000-7f41976fa000 r--s 00000000 08:11 5123453                    /var/cache/fontconfig/04aabc0a78ac019cf9454389977116d2-le64.cache-6
7f41976fa000-7f41976fb000 r--s 00000000 08:11 5123442                    /var/cache/fontconfig/1ac9eb803944fde146138c791f5cc56a-le64.cache-6
7f41976fb000-7f41976fc000 r--s 00000000 08:11 5123415                    /var/cache/fontconfig/b95bc8ffbebda2bbdae4265e45b8178d-le64.cache-6
7f41976fc000-7f4197700000 r--s 00000000 08:11 5123407                    /var/cache/fontconfig/385c0604a188198f04d133e54aba7fe7-le64.cache-6
7f4197700000-7f4197701000 r--s 00000000 08:11 5123358                    /var/cache/fontconfig/9c956a7723ca69a44b382d9179c9802f-le64.cache-6
7f4197701000-7f4197702000 r--s 00000000 08:11 5123349                    /var/cache/fontconfig/dc05db6664285cc2f12bf69c139ae4c3-le64.cache-6
7f4197702000-7f4197703000 r--s 00000000 08:11 5123345                    /var/cache/fontconfig/14a5e22175779b556eaa434240950366-le64.cache-6
7f4197703000-7f4197704000 r--s 00000000 08:11 5123344                    /var/cache/fontconfig/660208299946a285a940457d1287da33-le64.cache-6
7f4197704000-7f4197705000 r--s 00000000 08:11 5123343                    /var/cache/fontconfig/5d1cca7074f29429a8d18692746c2426-le64.cache-6
7f4197705000-7f4197708000 r--s 00000000 08:11 5123337                    /var/cache/fontconfig/767a8244fc0220cfb567a839d0392e0b-le64.cache-6
7f4197708000-7f419770a000 r--s 00000000 08:11 5121374                    /var/cache/fontconfig/69fb4bbe1b2fa860e172a32ebf28505c-le64.cache-6
7f419770a000-7f419770b000 r--s 00000000 08:11 5120233                    /var/cache/fontconfig/4794a0821666d79190d59a36cb4f44b5-le64.cache-6
7f419770b000-7f419770c000 r--s 00000000 08:11 5123259                    /var/cache/fontconfig/9eae20f1ff8cc0a7d125749e875856bd-le64.cache-6
7f419770c000-7f419774c000 r--s 00000000 08:11 5123216                    /var/cache/fontconfig/0bd3dc0958fa2205aaaa8ebb13e2872b-le64.cache-6
7f419774c000-7f419774f000 r--s 00000000 08:11 5123208                    /var/cache/fontconfig/bf2c1853a9e9b00bb02fe2e9bcf1e201-le64.cache-6
7f419774f000-7f4197754000 r--s 00000000 08:11 5123072                    /var/cache/fontconfig/8801497958630a81b71ace7c5f9b32a8-le64.cache-6
7f4197754000-7f419778f000 r--s 00000000 08:11 5116241                    /var/cache/fontconfig/365b55f210c0a22e9a19e35191240f32-le64.cache-6
7f419778f000-7f4197793000 r--s 00000000 08:11 5122969                    /var/cache/fontconfig/c57959a16110560c8d0fcea73374aeeb-le64.cache-6
7f4197793000-7f4197794000 r--s 00000000 08:11 5122946                    /var/cache/fontconfig/b872e6e592da6075ffa4ab0a1fcc0c75-le64.cache-6
7f4197794000-7f4197795000 r--s 00000000 08:11 5122927                    /var/cache/fontconfig/f6d4eedfaab2589bde49f7a3ff831d22-le64.cache-6
7f4197795000-7f4197796000 r--s 00000000 08:11 5122923                    /var/cache/fontconfig/589f83ef4c36d296ce6e1c846f468f08-le64.cache-6
7f4197796000-7f4197797000 r--s 00000000 08:11 5122909                    /var/cache/fontconfig/bab58bb527bb656aaa9f116d68a48d89-le64.cache-6
7f4197797000-7f4197798000 r--s 00000000 08:11 5122866                    /var/cache/fontconfig/2171a34dccabdb6bcbbc728186263178-le64.cache-6
7f4197798000-7f4197799000 r--s 00000000 08:11 5122851                    /var/cache/fontconfig/aec30016f93e1b46d1a973dce0d74068-le64.cache-6
7f4197799000-7f419779a000 r--s 00000000 08:11 5122769                    /var/cache/fontconfig/3f589640d34b7dc9042c8d453f7c8b9c-le64.cache-6
7f419779a000-7f419779b000 r--s 00000000 08:11 5122715                    /var/cache/fontconfig/16c2fda60d1b4b719f4b3d06fd951d25-le64.cache-6
7f419779b000-7f419779c000 r--s 00000000 08:11 5122676                    /var/cache/fontconfig/a48eab177a16e4f3713381162db2f3e9-le64.cache-6
7f419779c000-7f419779d000 r--s 00000000 08:11 5122669                    /var/cache/fontconfig/564b2e68ac9bc4e36a6f7f6d6125ec1c-le64.cache-6
7f419779d000-7f41977a4000 r--s 00000000 08:11 5122656                    /var/cache/fontconfig/3047814df9a2f067bd2d96a2b9c36e5a-le64.cache-6
7f41977a4000-7f41977ac000 r--s 00000000 08:11 5122637                    /var/cache/fontconfig/bf3b770c553c462765856025a94f1ce6-le64.cache-6
7f41977ac000-7f41977ad000 r--s 00000000 08:11 5122599                    /var/cache/fontconfig/56cf4f4769d0f4abc89a4895d7bd3ae1-le64.cache-6
7f41977ad000-7f41977ae000 r--s 00000000 08:11 5122584                    /var/cache/fontconfig/b9d506c9ac06c20b433354fa67a72993-le64.cache-6
7f41977ae000-7f41977b4000 r--s 00000000 08:11 5122568                    /var/cache/fontconfig/b47c4e1ecd0709278f4910c18777a504-le64.cache-6
7f41977b4000-7f41977b5000 r--s 00000000 08:11 5122449                    /var/cache/fontconfig/89034621ae2a8922916bb6bfa5799546-le64.cache-6
7f41977b5000-7f41977bd000 r--s 00000000 08:11 5122543                    /var/cache/fontconfig/52f7bdb7ce746bfd7eaa1985bd9cfa93-le64.cache-6
7f41977bd000-7f41977bf000 r--s 00000000 08:11 5118126                    /var/cache/fontconfig/a0107c79d978dfcc5e42cb1335b71036-le64.cache-6
7f41977bf000-7f41977c1000 r--s 00000000 08:11 5122509                    /var/cache/fontconfig/4b14b093aebc79c320de5e86ae1d3314-le64.cache-6
7f41977c1000-7f41977c2000 r--s 00000000 08:11 5122495                    /var/cache/fontconfig/8aec10f4cc8391dcef22ca549f1e4354-le64.cache-6
7f41977c2000-7f41977d5000 r--s 00000000 08:11 5122424                    /var/cache/fontconfig/d52a8644073d54c13679302ca1180695-le64.cache-6
7f41977d5000-7f41977d6000 r--s 00000000 08:11 5122372                    /var/cache/fontconfig/370e5b74bf5dafc30834de68e24a87a4-le64.cache-6
7f41977d6000-7f41977d7000 r--s 00000000 08:11 5122369                    /var/cache/fontconfig/6b2c5944714ca7831b25bed9e85cb5c8-le64.cache-6
7f41977d7000-7f41977d8000 r--s 00000000 08:11 5122310                    /var/cache/fontconfig/d5178ab6d91b49bf20a416737dcea9e8-le64.cache-6
7f41977d8000-7f41977d9000 r--s 00000000 08:11 5122306                    /var/cache/fontconfig/551ecf3b0e8b0bca0f25c0944f561853-le64.cache-6
7f41977d9000-7f41977dc000 r--s 00000000 08:11 5122304                    /var/cache/fontconfig/f259c2cffa685e28062317905db73c4a-le64.cache-6
7f41977dc000-7f41977de000 r--s 00000000 08:11 5122300                    /var/cache/fontconfig/550f3886151c940c12a5ed35f6a00586-le64.cache-6
7f41977de000-7f41977e1000 r--s 00000000 08:11 5122297                    /var/cache/fontconfig/674d1711f2d1d2a09646eb0bdcadee49-le64.cache-6
7f41977e1000-7f41977e2000 r--s 00000000 08:11 5122252                    /var/cache/fontconfig/8a687c406b77f27d99abfeeba937fcce-le64.cache-6
7f41977e2000-7f41977e3000 r--s 00000000 08:11 5122243                    /var/cache/fontconfig/ac2cf712d852da827a87a9baf682f5b9-le64.cache-6
7f41977e3000-7f41977e5000 r--s 00000000 08:11 5122229                    /var/cache/fontconfig/65f976e5259cbe6dc7697b8648396239-le64.cache-6
7f41977e5000-7f41977f0000 r--s 00000000 08:11 5122216                    /var/cache/fontconfig/d589a48862398ed80a3d6066f4f56f4c-le64.cache-6
7f41977f0000-7f41977f1000 r--s 00000000 08:11 5122154                    /var/cache/fontconfig/845c20fd2c4814bcec78e05d37a63ccc-le64.cache-6
7f41977f1000-7f41977f2000 r--s 00000000 08:11 5122124                    /var/cache/fontconfig/e7de81b01590fb7e12b38e274e17d0db-le64.cache-6
7f41977f2000-7f41977f4000 r--s 00000000 08:11 5122049                    /var/cache/fontconfig/67709b7835c0f764c1135060c9575660-le64.cache-6
7f41977f4000-7f41977f5000 r--s 00000000 08:11 5122042                    /var/cache/fontconfig/0c9eb80ebd1c36541ebe2852d3bb0c49-le64.cache-6
7f41977f5000-7f4197807000 r--s 00000000 08:11 5121795                    /var/cache/fontconfig/9b89f8e3dae116d678bbf48e5f21f69b-le64.cache-6
7f4197807000-7f4197810000 r--s 00000000 08:11 5121785                    /var/cache/fontconfig/d0972c3d32f097851eb916381fc38920-le64.cache-6
7f4197810000-7f4197830000 r--s 00000000 08:11 5121423                    /var/cache/fontconfig/e13b20fdb08344e0e664864cc2ede53d-le64.cache-6
7f4197830000-7f419783a000 rw-p 00000000 00:00 0 
7f419783a000-7f419783b000 r--s 00000000 08:11 5122000                    /var/cache/fontconfig/22368d551a680bfe5a62c02760edf4ea-le64.cache-6
7f419783b000-7f419783c000 r--s 00000000 08:11 5121929                    /var/cache/fontconfig/4d9c95eba1cb85bbcf2878543262124a-le64.cache-6
7f419783c000-7f419783d000 r--s 00000000 08:11 5121846                    /var/cache/fontconfig/85e0a52ce643a7ba2ae53e5d6949cead-le64.cache-6
7f419783d000-7f419783e000 r--s 00000000 08:11 5121844                    /var/cache/fontconfig/49f0de54bdd920fe4f0dfd4cbac43e6b-le64.cache-6
7f419783e000-7f419783f000 r--s 00000000 08:11 5121818                    /var/cache/fontconfig/f6e6e0a5c3d2f6ae0c0c2e0ecd42a997-le64.cache-6
7f419783f000-7f4197840000 r--s 00000000 08:11 5121816                    /var/cache/fontconfig/4b2eda6bb976bda485cb2176619421d5-le64.cache-6
7f4197840000-7f4197841000 r--s 00000000 08:11 5121701                    /var/cache/fontconfig/c277e94e32b20404286a1ddafa5a80f0-le64.cache-6
7f4197841000-7f4197842000 r--s 00000000 08:11 5121655                    /var/cache/fontconfig/1f6eab6b3c1c88a61c6a19ff3f39ab3b-le64.cache-6
7f4197842000-7f4197843000 r--s 00000000 08:11 5121623                    /var/cache/fontconfig/3fe29f0c9fa221c8ee16555d4835b3ab-le64.cache-6
7f4197843000-7f4197844000 r--s 00000000 08:01 4143628                    /media/storage/cache/fontconfig/88c2262882eb76852818d46dff75e954-le64.cache-6
7f4197844000-7f4197845000 r--s 00000000 08:01 4143626                    /media/storage/cache/fontconfig/e288cb67cda53cb2c05ff841de05b603-le64.cache-6
7f4197845000-7f4197849000 r--s 00000000 08:11 5113283                    /var/cache/fontconfig/7ef2298fde41cc6eeb7af42e48b7d293-le64.cache-6
7f4197849000-7f419784a000 r--s 00000000 08:11 5113846                    /var/cache/fontconfig/573ec803664ed168555e0e8b6d0f0c7f-le64.cache-6
7f419784a000-7f419784c000 r--s 00000000 08:11 5124015                    /var/cache/fontconfig/16326683038b281783a0ef8c680e3a10-le64.cache-6
7f419784c000-7f4197859000 r--s 00000000 08:11 5123984                    /var/cache/fontconfig/8f02d4cb045bd6ce15663e43f347c9f8-le64.cache-6
7f4197859000-7f419785a000 r--s 00000000 08:11 5123914                    /var/cache/fontconfig/e0aa53bcfa504e64f8782
7f419785a000-7f419787b000 r--s 00000000 08:11 5123907                    /var/cache/fontconfig/467c019e582ee353435ea
7f419787b000-7f419787c000 r--s 00000000 08:01 4074437                    /media/storage/cache/fontconfig/0b5be334dc7
7f419787c000-7f4197880000 r--s 00000000 08:01 4143478                    /media/storage/cache/fontconfig/8ee23652a55
7f4197880000-7f4197881000 r--p 00025000 08:11 5245444                    /lib/x86_64-linux-gnu/ld-2.23.so
7f4197881000-7f4197882000 rw-p 00026000 08:11 5245444                    /lib/x86_64-linux-gnu/ld-2.23.so
7f4197882000-7f4197883000 rw-p 00000000 00:00 0 
7ffdd3fdb000-7ffdd3ffc000 rw-p 00000000 00:00 0                          [stack]
7ffdd3ffc000-7ffdd3ffe000 r--p 00000000 00:00 0                          [vvar]
7ffdd3ffe000-7ffdd4000000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
Abortado (`core' generado)
```

Change the value to 
```
unsigned int defaultbg = 257
```

Solves this issue.