### PR TITLE
Correct gruvbox defaultfg and cursor colors

### DIFF
--- a/config.h
+++ b/config.h
@@ -102,9 +102,10 @@ static const char *colorname[] = {
 	"#d3869b",
 	"#8ec07c",
 	"#ebdbb2",
+	[255] = 0,
 	/* more colors can be added after 255 to use with DefaultXX */
 	"black",   /* 256 -> bg */
-	"brwhite", /* 257 -> fg */
+	"white",   /* 257 -> fg */
 };
 
 
@@ -112,10 +113,10 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-unsigned int defaultfg = 12;
+unsigned int defaultfg = 15;
 unsigned int defaultbg = 0;
-static unsigned int defaultcs = 14;
-static unsigned int defaultrcs = 15;
+static unsigned int defaultcs = 15;
+static unsigned int defaultrcs = 0;
 
 /*
  * Default shape of cursor


### PR DESCRIPTION
With the gruvbox update defaultfg and default cursors were left at Solarized's values, leaving default text a sickly blue. See [gruvbox st port](https://github.com/morhetz/gruvbox-contrib/blob/master/st/gruvbox-dark.h).

Also, the lines just after 105 were previously ignored since they counted as colors 16 and 17 instead of 256 and 257 (see x.c line 736). New line 105 gives them back their intended index values. While these lines can now be used, they're not at the moment, so they could just be deleted as well.

When no longer ignored, "brwhite" caused errors (not an accepted color name), so changed.