### PR TITLE
Added Xresource border to adjust the internal border.

### DIFF
--- a/config.h
+++ b/config.h
@@ -179,7 +179,8 @@ ResourcePref resources[] = {
 		{ "tabspaces",    INTEGER, &tabspaces },
 		{ "cwscale",      FLOAT,   &cwscale },
 		{ "chscale",      FLOAT,   &chscale },
-		{ "alpha",      INTEGER,   &alpha },
+		{ "alpha",        INTEGER, &alpha },
+		{ "border",       INTEGER, &borderpx },
 };
 
 /*


### PR DESCRIPTION
Tested by adding `*border` on my `.Xresources` file. Reran `xrdb ~/.Xresources`. Ran `st`. Border changed as expected.

Maybe consider naming internalBorder to match how URxvt treats it and for better accuracy. Initially didn't simply because it would ruin the entire style of the array initialization (I know a bit silly).