### PR TITLE
Use conditional variable assignment for PREFIX

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -4,7 +4,7 @@ VERSION = 0.8.1
 # Customize below to fit your system
 
 # paths
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 MANPREFIX = $(PREFIX)/share/man
 
 X11INC = /usr/X11R6/include


### PR DESCRIPTION
This will allow people to assign a different `PREFIX` value without having to modify `config.mk` manually.

For example, under `fish`:

    env PREFIX= DESTDIR=~/.local/bin make install