### PR TITLE
correct colorname declaration

### DIFF
--- a/config.h
+++ b/config.h
@@ -5,8 +5,9 @@
  *
  * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
  */
-static char *font = "mono:pixelsize=16:antialias=true:autohint=true";
-static int borderpx = 2;
+//static char *font = "monospace:pixelsize=28:antialias=true:autohint=true:dpi=168";
+static char *font = "mono:pixelsize=28:antialias=true:autohint=false:hinting=false:hintstyle=2:dpi=168";
+static int borderpx = 4;
 
 /*
  * What program is execed by st depends of these precedence rules:
@@ -113,8 +114,8 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-unsigned int defaultfg = 15;
-unsigned int defaultbg = 0;
+unsigned int defaultfg = 257;
+unsigned int defaultbg = 256;
 static unsigned int defaultcs = 15;
 static unsigned int defaultrcs = 0;
 

--- a/config.h
+++ b/config.h
@@ -5,9 +5,8 @@
  *
  * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
  */
-//static char *font = "monospace:pixelsize=28:antialias=true:autohint=true:dpi=168";
-static char *font = "mono:pixelsize=28:antialias=true:autohint=false:hinting=false:hintstyle=2:dpi=168";
-static int borderpx = 4;
+static char *font = "mono:pixelsize=16:antialias=true:autohint=true";
+static int borderpx = 2;
 
 /*
  * What program is execed by st depends of these precedence rules:
@@ -108,6 +107,7 @@ static const char *colorname[] = {
 	/* more colors can be added after 255 to use with DefaultXX */
 	"black",   /* 256 -> bg */
 	"white",   /* 257 -> fg */
+	"#add8e6", /* 258 -> cursor */
 };
 
 

--- a/refresh.sh
+++ b/refresh.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sudo make uninstall && make clean && make && sudo make install


### PR DESCRIPTION
The cursorColor references colorname[258] element but this is not declared in the definition.  This pull request updates the colorname declaration with a 258th element.

Symptoms are: #71  and also other weird behaviour - I'm surprised the current version works for people?  Maybe it's because I actually have the `*.cursorColor:  #add8e6` defined in my .Xresources.

(Note - it also includes defining the default bg and foreground colors to 256 and 257 which for some reason weren't set correctly?  + my own "refresh" script for rebuilding)