### PR TITLE
Premultiply background RGB values if alpha is used

### DIFF
--- a/x.c
+++ b/x.c
@@ -784,9 +784,15 @@ xloadcols(void)
 	/* set alpha value of bg color */
 	if (opt_alpha)
 		alpha = strtof(opt_alpha, NULL);
-		dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * alpha);
-		dc.col[defaultbg].pixel &= 0x00FFFFFF;
-		dc.col[defaultbg].pixel |= (unsigned char)(0xff * alpha) << 24;
+	dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * alpha);
+	dc.col[defaultbg].color.red =
+		((unsigned short)(dc.col[defaultbg].color.red * alpha)) & 0xff00;
+	dc.col[defaultbg].color.green =
+		((unsigned short)(dc.col[defaultbg].color.green * alpha)) & 0xff00;
+	dc.col[defaultbg].color.blue =
+		((unsigned short)(dc.col[defaultbg].color.blue * alpha)) & 0xff00;
+	dc.col[defaultbg].pixel &= 0x00FFFFFF;
+	dc.col[defaultbg].pixel |= (unsigned char)(0xff * alpha) << 24;
 	loaded = 1;
 }
 


### PR DESCRIPTION
Most composite managers uses [premultiplied RGB](https://en.wikipedia.org/wiki/Alpha_compositing) color when alpha blending. 

The [st-alpha-0.8.2.diff](https://st.suckless.org/patches/alpha/st-alpha-0.8.2.diff) doesn't contain the premultiplication fix present in the [st-alpha-20190116-3be4cf1.diff](https://st.suckless.org/patches/alpha/st-alpha-20190116-3be4cf1.diff). 

In this PR I reimplemented the premultiplication using the new float alpha parameter maintaining the 8-bit padded ushort for each channel.