### PR TITLE
additional Xresources item compatible with font2 patch

### DIFF
--- a/config.h
+++ b/config.h
@@ -155,6 +155,7 @@ static unsigned int defaultattr = 11;
  */
 ResourcePref resources[] = {
 		{ "font",         STRING,  &font },
+		{ "fontalt0",     STRING,  &font2[0] },
 		{ "color0",       STRING,  &colorname[0] },
 		{ "color1",       STRING,  &colorname[1] },
 		{ "color2",       STRING,  &colorname[2] },


### PR DESCRIPTION
Hi,
I noticed your addition of the font2 patch recently.
Short story:
I've modified the resources array to take an item for the font2 array.

Long story:
I switch between laptop and monitors regularly which have different resolutions.  A bit of scripting and some variables in my Xresources help with the switching resolutions.  Having the Xresources patch is in st makes this a breeze.  The addition of font2 made this incompatible but it's pretty simple to add this into the reources array. For interest my Xresources is below:
https://gist.github.com/rjl6789/115d5494406d82060b0ec592151639dd

Cheers

Rob
