### PR TITLE
Grab last output to vim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,10 @@ install: st
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp -f st $(DESTDIR)$(PREFIX)/bin
 	cp -f st-copyout $(DESTDIR)$(PREFIX)/bin
+	cp -f st-grab-last-out $(DESTDIR)$(PREFIX)/bin
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/st
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/st-copyout
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/st-grab-last-out
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	sed "s/VERSION/$(VERSION)/g" < st.1 > $(DESTDIR)$(MANPREFIX)/man1/st.1
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/st.1
@@ -55,6 +57,7 @@ install: st
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/st
 	rm -f $(DESTDIR)$(PREFIX)/bin/st-copyout
+	rm -f $(DESTDIR)$(PREFIX)/bin/st-grab-last-out
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/st.1
 
 .PHONY: all options clean dist install uninstall

--- a/config.h
+++ b/config.h
@@ -221,6 +221,7 @@ static char *copyurlcmd[] = { "/bin/sh", "-c",
     "externalpipe", NULL };
 
 static char *copyoutput[] = { "/bin/sh", "-c", "st-copyout", "externalpipe", NULL };
+static char *grablastoutput[] = { "/bin/sh", "-c", "st-grab-last-out", "externalpipe", NULL };
 
 static Shortcut shortcuts[] = {
 	/* mask                 keysym          function        argument */
@@ -256,6 +257,7 @@ static Shortcut shortcuts[] = {
 	{ MODKEY,               XK_l,           externalpipe,   {.v = openurlcmd } },
 	{ MODKEY,               XK_y,           externalpipe,   {.v = copyurlcmd } },
 	{ MODKEY,               XK_o,           externalpipe,   {.v = copyoutput } },
+	{ MODKEY,               XK_g,           externalpipe,   {.v = grablastoutput } },
 };
 
 /*

--- a/st-grab-last-out
+++ b/st-grab-last-out
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Using external pipe with st, give a dmenu prompt of recent commands,
+# allowing the user to copy the output of one.
+# xclip required for this script.
+# By Jaywalker and Luke
+tmpfile=$(mktemp /tmp/st-cmd-output.XXXXXX)
+tmpfile2=$(mktemp /tmp/st-cmd-output.XXXXXX)
+trap 'rm "$tmpfile"' 0 1 15
+trap 'rm "$tmpfile2"' 0 1 15
+sed -n "w $tmpfile"
+ps1="$(grep "\S" "$tmpfile" | tail -n 1 | cut -d' ' -f1)"
+eps1="$(echo "$ps1" | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
+sed -i '$ d' "$tmpfile"
+awk "/^$eps1/{t=1;p=1}
+	t{a[p]=\$0; p=p+1}
+	END{for (i=1; i<p; ++i) print a[i];}" "$tmpfile" >> $tmpfile2
+# awk "/^$chosen$/{p=1;print;next} p&&/^$eps1/{p=0};p" "$tmpfile" >> $tmpfile2
+st -e "$EDITOR" "$tmpfile2"

--- a/st.1
+++ b/st.1
@@ -157,6 +157,9 @@ Show dmenu menu of all recently run commands and copy the output of the chosen c
 .I xclip
 required.
 .TP
+.B Alt-g
+Grab last command with its output opening $EDITOR with the result on new st terminal
+.TP
 .B Break
 Send a break in the serial line.
 Break key is obtained in PC keyboards


### PR DESCRIPTION
##### SUMMARY
Grab last output command to $EDITOR

##### DESCRITION
add new keybind "Alt-g" for "Grab" the last output.
meaning copy the last command with it's output for further manipulation or selective yanking/coping

##### MAN DESCRIPTION
Grab last command with its output opening $EDITOR with the result on new st terminal