### PR TITLE
fix prompt starting with space(s)

### DIFF
--- a/st-copyout
+++ b/st-copyout
@@ -6,7 +6,7 @@
 tmpfile=$(mktemp /tmp/st-cmd-output.XXXXXX)
 trap 'rm "$tmpfile"' 0 1 15
 sed -n "w $tmpfile"
-ps1="$(grep "\S" "$tmpfile" | tail -n 1 | cut -d' ' -f1)"
+ps1="$(grep "\S" "$tmpfile" | tail -n 1 | sed 's/^\s*//' | cut -d' ' -f1)"
 chosen="$(grep -F "$ps1" "$tmpfile" | sed '$ d' | tac | dmenu -p "Copy which command's output?" -i -l 10 | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
 eps1="$(echo "$ps1" | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
 awk "/^$chosen$/{p=1;print;next} p&&/^$eps1/{p=0};p" "$tmpfile" | xclip -selection clipboard


### PR DESCRIPTION
I've a prompt which starts with a space and looks like this:
` undx@rogue  ~/Code/local/st  ➦ bf29538 `
` ✘ undx@rogue  ~ `
Maybe I'm not the only one in that case...