### PR TITLE
fix excessive slurping when prompt starts w/ space(s)

### DIFF
--- a/st-copyout
+++ b/st-copyout
@@ -9,4 +9,4 @@ sed -n "w $tmpfile"
 ps1="$(grep "\S" "$tmpfile" | tail -n 1 | sed 's/^\s*//' | cut -d' ' -f1)"
 chosen="$(grep -F "$ps1" "$tmpfile" | sed '$ d' | tac | dmenu -p "Copy which command's output?" -i -l 10 | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
 eps1="$(echo "$ps1" | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
-awk "/^$chosen$/{p=1;print;next} p&&/^$eps1/{p=0};p" "$tmpfile" | xclip -selection clipboard
+awk "/^$chosen$/{p=1;print;next} p&&/$eps1/{p=0};p" "$tmpfile" | xclip -selection clipboard


### PR DESCRIPTION
Realized that awk was slurping too much data when prompts starts with a space.
As `esp1` may be stripped, the pattern may not be found (`^$esp`) and goes to end of output.
This may add space(s) to the end to output.
