### PR TITLE
Add background, foreground, cursor color example

### DIFF
--- a/.Xdefaults
+++ b/.Xdefaults
@@ -7,6 +7,11 @@ st.font: Monospace-11;
 ! st.termname: st-256color
 ! st.borderpx: 2
 
+!! Set the background, foreground and cursor colors as below:
+*.background: #282828
+*.foreground: white
+*.cursorColor: white
+
 /* !! gruvbox: */
 /* *.color0: #1d2021 */
 /* *.color1: #cc241d */


### PR DESCRIPTION
You might want to update every theme with different colors - I just didn't knew which ones to put there

(or maybe just mimic `color0` as `background` & `color15` as `foreground` and `cursorColor` (see the diff @ #108))

~~Fixes #108; fixes #97~~

There are apparently some issues with [`pywal`](https://github.com/dylanaraps/pywal/wiki/Getting-Started), see https://github.com/LukeSmithxyz/st/issues/108#issuecomment-506974909