### PR TITLE
fix wal bg-color update issue

### DIFF
--- a/config.h
+++ b/config.h
@@ -124,8 +124,8 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-unsigned int defaultfg = 259;
-unsigned int defaultbg = 258;
+unsigned int defaultfg = 7;
+unsigned int defaultbg = 0;
 static unsigned int defaultcs = 256;
 static unsigned int defaultrcs = 257;
 


### PR DESCRIPTION
The background color of `st` does not update after running `wal`.
Only new instances of `st` have the new bg color.
That's not the case with the original `st` from suckless.org.

A quick fix I found is to reset the value of two variables in `config.h` according to `suckless.org/st/config.def.h` (see commit).

I don't really understand what's going on and I haven't really tested that well, but I found a PR more appropriate than raising an issue.
Sorry if it breaks something I haven't considered. Use with care.