### PR TITLE
AlphaFocusHighlight patch instead of Alpha patch.

### DIFF
--- a/.Xdefaults
+++ b/.Xdefaults
@@ -1,5 +1,6 @@
 !! Transparency (0-1):
 st.alpha: 0.92
+st.alphaUnfocussed: 0.8
 
 !! Set a default font and font size as below:
 st.font: Monospace-11;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What, why, and how?
 
-+ **What is this fork?** This is a fork of Luke's st build that replaces the [alpha patch](st.suckless.org/patches/alpha/) with the [alphafocushighlighting patch.](st.suckless.org/patches/alpha_focus_highlight/) This build is kept up to date with lukes build and the latest releases for the alphahighlighting patch. If it's not up to date, just make a pull request and I'll merge it when I feel like it, if you're too lazy to make one, just wait for me to upate it.
++ **What is this fork?** This is a fork of Luke's st build that replaces the [alpha patch](https://st.suckless.org/patches/alpha/) with the [alphafocushighlighting patch.](https://st.suckless.org/patches/alpha_focus_highlight/) This build is kept up to date with lukes build and the latest releases for the alphahighlighting patch. If it's not up to date, just make a pull request and I'll merge it when I feel like it, if you're too lazy to make one, just wait for me to upate it.
 
 + **Why does this fork exist?** This fork exists because if you decide not to have big O'l borders and gaps and you use something like unclutter, it can be hard to tell which terminal is currently focused, this makes it easy and pretty. Functionality and looks nice? Impossible.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# What, why, and how?
+
++ **What is this fork?** This is a fork of Luke's st build that replaces the alpha patch with the alphahighlighting patch. This build is kept up to date with lukes build and the latest releases for the alphahighlighting patch. If it's not up to date, just make a pull request and I'll merge it when I feel like it, if you're too lazy to make one, just wait for me to upate it.
+
++ **Why does this fork exist?** This fork exists because if you decide not to have big O'l borders and gaps and you use something like unclutter, it can be hard to tell which terminal is currently focused, this makes it easy and pretty. Functionality and looks nice? Impossible.
+
++ **Why don't you make your own build?** Because Luke's build is almost perfect, link following, etc, etc, but it wasn't exactly what I wanted so i forked it. Another reason is people are always impoving and updating his build, so all I have to do is keep the patch up to date. EzLyfFoMi
+
++ **How do I use this?** Both of the alpha values can be set in the config.h or can be set in .Xresources, so if you do use .Xresources, (please don't use .Xresources) then theres an example in the .Xdefaults file in this repo.
+
 # Luke's build of st - the simple (suckless) terminal
 
 The [suckless terminal (st)](https://st.suckless.org/) with some additional features that make it literally the best terminal emulator ever:
@@ -53,7 +63,8 @@ For example, you can define your desired fonts, transparency or colors:
 
 ```
 *.font:	Liberation Mono:pixelsize=12:antialias=true:autohint=true;
-*.alpha: 0.9
+*.alpha: 0.92
+st.alphaUnfocussed: 0.8
 *.color0: #111
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What, why, and how?
 
-+ **What is this fork?** This is a fork of Luke's st build that replaces the alpha patch with the alphahighlighting patch. This build is kept up to date with lukes build and the latest releases for the alphahighlighting patch. If it's not up to date, just make a pull request and I'll merge it when I feel like it, if you're too lazy to make one, just wait for me to upate it.
++ **What is this fork?** This is a fork of Luke's st build that replaces the [alpha patch](st.suckless.org/patches/alpha/) with the [alphafocushighlighting patch.](st.suckless.org/patches/alpha_focus_highlight/) This build is kept up to date with lukes build and the latest releases for the alphahighlighting patch. If it's not up to date, just make a pull request and I'll merge it when I feel like it, if you're too lazy to make one, just wait for me to upate it.
 
 + **Why does this fork exist?** This fork exists because if you decide not to have big O'l borders and gaps and you use something like unclutter, it can be hard to tell which terminal is currently focused, this makes it easy and pretty. Functionality and looks nice? Impossible.
 

--- a/config.h
+++ b/config.h
@@ -91,7 +91,8 @@ char *termname = "st-256color";
 unsigned int tabspaces = 8;
 
 /* bg opacity */
-float alpha = 0.92;
+float alpha = 0.92;		//< alpha value used when the window is focused.
+float alphaUnfocussed = 0.8;	//< alpha value used when the focus is lost
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {

--- a/st.h
+++ b/st.h
@@ -132,5 +132,6 @@ extern unsigned int tabspaces;
 extern unsigned int defaultfg;
 extern unsigned int defaultbg;
 extern float alpha;
+extern float alphaUnfocussed;
 extern MouseKey mkeys[];
 extern int ximspot_update_interval;

--- a/x.c
+++ b/x.c
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <locale.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <sys/select.h>
 #include <time.h>
 #include <unistd.h>
@@ -261,6 +262,7 @@ static char *opt_io    = NULL;
 static char *opt_line  = NULL;
 static char *opt_name  = NULL;
 static char *opt_title = NULL;
+static bool focused = true;
 
 static int oldbutton = 3; /* button event on startup: 3 = release */
 
@@ -766,6 +768,20 @@ xloadcolor(int i, const char *name, Color *ncolor)
 }
 
 void
+xloadalpha(void)
+{
+    /* set alpha value of bg color */
+    if (opt_alpha)
+        alpha = strtof(opt_alpha, NULL);
+
+    float const usedAlpha = focused ? alpha : alphaUnfocussed;
+
+    dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * usedAlpha);
+    dc.col[defaultbg].pixel &= 0x00FFFFFF;
+    dc.col[defaultbg].pixel |= (unsigned char)(0xff * usedAlpha) << 24;
+}
+
+void
 xloadcols(void)
 {
 	int i;
@@ -788,19 +804,9 @@ xloadcols(void)
 				die("could not allocate color %d\n", i);
 		}
 
-	/* set alpha value of bg color */
-	if (opt_alpha)
-		alpha = strtof(opt_alpha, NULL);
-	dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * alpha);
-	dc.col[defaultbg].color.red =
-		((unsigned short)(dc.col[defaultbg].color.red * alpha)) & 0xff00;
-	dc.col[defaultbg].color.green =
-		((unsigned short)(dc.col[defaultbg].color.green * alpha)) & 0xff00;
-	dc.col[defaultbg].color.blue =
-		((unsigned short)(dc.col[defaultbg].color.blue * alpha)) & 0xff00;
-	dc.col[defaultbg].pixel &= 0x00FFFFFF;
-	dc.col[defaultbg].pixel |= (unsigned char)(0xff * alpha) << 24;
-	loaded = 1;
+	xloadalpha();
+ 	loaded = 1;
+
 }
 
 int
@@ -1812,13 +1818,23 @@ focus(XEvent *ev)
 		XSetICFocus(xw.xic);
 		win.mode |= MODE_FOCUSED;
 		xseturgency(0);
-		if (IS_SET(MODE_FOCUS))
 			ttywrite("\033[I", 3, 0);
+		if (!focused) {
+			focused = true;
+			xloadalpha();
+			redraw();
+		}
 	} else {
 		XUnsetICFocus(xw.xic);
 		win.mode &= ~MODE_FOCUSED;
 		if (IS_SET(MODE_FOCUS))
 			ttywrite("\033[O", 3, 0);
+		if (focused) {
+			focused = false;
+			xloadalpha();
+			redraw();
+		}
+
 	}
 }
 

--- a/x.c
+++ b/x.c
@@ -1818,6 +1818,7 @@ focus(XEvent *ev)
 		XSetICFocus(xw.xic);
 		win.mode |= MODE_FOCUSED;
 		xseturgency(0);
+ 		if (IS_SET(MODE_FOCUS))
 			ttywrite("\033[I", 3, 0);
 		if (!focused) {
 			focused = true;


### PR DESCRIPTION
alpha-focus-highlight is an alternative patch to the alpha patch. It adds two alpha values, one for when the terminal is not focused and one for when it is. 

The defaults I set are 0.92 (Luke's default) as focused alpha value, and 0.8 as default unfocused alpha value. This doesn't look very good, so if this does get merged, I would either change the default background to black or set both values the same and mention in the readme that the patch exists.

I also added `st.alphaUnfocussed: 0.8` to the .Xdefault example for those who install from the aur. Again, might want to change the default background color or the values in this file as well.

Personally I think it not only looks good, it's also very helpful to those who use minimalist window managers with unclutter or something similar to be able to see which terminal is currently focused without paying attention to the border.

There really isn't a downside I can see, if someone doesn't like the behavior, they can set both values as the same, and the effect will be no different from the normal alpha patch.

Currently the newest version of Luke's terminal with this patch can be found on my github here. -> github.com/lordrusk/st