### PR TITLE
Do not copy text to clipboard after selecting

### DIFF
--- a/x.c
+++ b/x.c
@@ -661,8 +661,6 @@ setsel(char *str, Time t)
 	XSetSelectionOwner(xw.dpy, XA_PRIMARY, xw.win, t);
 	if (XGetSelectionOwner(xw.dpy, XA_PRIMARY) != xw.win)
 		selclear();
-
-	clipcopy(NULL);
 }
 
 void


### PR DESCRIPTION
This behaviour was introduced in https://github.com/LukeSmithxyz/st/commit/683341140065b3096ee9e7e3e3b042f9c52230a6
Resolves: #177