### PR TITLE
Get rid of NUL character in PS1

### DIFF
--- a/st-copyout
+++ b/st-copyout
@@ -6,6 +6,7 @@
 tmpfile=$(mktemp /tmp/st-cmd-output.XXXXXX)
 trap 'rm "$tmpfile"' 0 1 15
 sed -n "w $tmpfile"
+sed -i 's/\x0//g' "$tmpfile"
 ps1="$(grep "\S" "$tmpfile" | tail -n 1 | sed 's/^\s*//' | cut -d' ' -f1)"
 chosen="$(grep -F "$ps1" "$tmpfile" | sed '$ d' | tac | dmenu -p "Copy which command's output?" -i -l 10 | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
 eps1="$(echo "$ps1" | sed 's/[^^]/[&]/g; s/\^/\\^/g')"


### PR DESCRIPTION
The first grep in the original script will return "binary file matches" if there are NUL characters in PS1, e.g, emojis.
The added line gets rid of NUL characters.