### PR TITLE
Pywal live reload with OSC patch and transparency fix

### DIFF
--- a/config.h
+++ b/config.h
@@ -108,7 +108,7 @@ char *termname = "st-256color";
 unsigned int tabspaces = 8;
 
 /* bg opacity */
-float alpha = 0.8;
+float alpha = 0.9;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {

--- a/config.h
+++ b/config.h
@@ -143,8 +143,8 @@ static const char *colorname[] = {
  */
 unsigned int defaultfg = 259;
 unsigned int defaultbg = 258;
-static unsigned int defaultcs = 256;
-static unsigned int defaultrcs = 257;
+unsigned int defaultcs = 256;
+unsigned int defaultrcs = 257;
 
 /*
  * Default shape of cursor

--- a/config.h
+++ b/config.h
@@ -108,7 +108,7 @@ char *termname = "st-256color";
 unsigned int tabspaces = 8;
 
 /* bg opacity */
-float alpha = 0.9;
+float alpha = 0.8;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {

--- a/st.c
+++ b/st.c
@@ -1943,12 +1943,23 @@ strhandle(void)
 			}
 			return;
 		case 4: /* color set */
-			if (narg < 3)
+		case 10: /* foreground set */
+		case 11: /* background set */
+		case 12: /* cursor color */
+			if ((par == 4 && narg < 3) || narg < 2)
 				break;
-			p = strescseq.args[2];
+			p = strescseq.args[((par == 4) ? 2 : 1)];
 			/* FALLTHROUGH */
 		case 104: /* color reset, here p = NULL */
-			j = (narg > 1) ? atoi(strescseq.args[1]) : -1;
+			if (par == 10)
+				j = defaultfg;
+			else if (par == 11)
+				j = defaultbg;
+			else if (par == 12)
+				j = defaultcs;
+			else
+				j = (narg > 1) ? atoi(strescseq.args[1]) : -1;
+
 			if (xsetcolorname(j, p)) {
 				if (par == 104 && narg <= 1)
 					return; /* color reset without parameter */

--- a/st.c
+++ b/st.c
@@ -1970,6 +1970,8 @@ strhandle(void)
 				 * TODO if defaultbg color is changed, borders
 				 * are dirty
 				 */
+				if (j == defaultbg)
+					xclearwin();
 				redraw();
 			}
 			return;

--- a/st.h
+++ b/st.h
@@ -140,6 +140,7 @@ extern char *termname;
 extern unsigned int tabspaces;
 extern unsigned int defaultfg;
 extern unsigned int defaultbg;
+extern unsigned int defaultcs;
 extern const int boxdraw, boxdraw_bold, boxdraw_braille;
 extern float alpha;
 extern MouseKey mkeys[];

--- a/win.h
+++ b/win.h
@@ -37,3 +37,4 @@ void xsetpointermotion(int);
 void xsetsel(char *);
 int xstartdraw(void);
 void xximspot(int, int);
+void xclearwin(void);

--- a/x.c
+++ b/x.c
@@ -832,6 +832,13 @@ xclear(int x1, int y1, int x2, int y2)
 }
 
 void
+xclearwin(void)
+{
+	xclear(0, 0, win.w, win.h);
+}
+
+
+void
 xhints(void)
 {
 	XClassHint class = {opt_name ? opt_name : "st",

--- a/x.c
+++ b/x.c
@@ -814,6 +814,8 @@ xsetcolorname(int x, const char *name)
 
 	XftColorFree(xw.dpy, xw.vis, xw.cmap, &dc.col[x]);
 	dc.col[x] = ncolor;
+	if (x == defaultbg)
+		dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * alpha);
 
 	return 0;
 }


### PR DESCRIPTION
Added OSC patch ( https://st.suckless.org/patches/osc_10_11_12/ ) which allows for changing the background, foreground, and cursor color on the fly using OSC escape codes 10, 11 and 12. I also made a small change in x.c to preserve the background transparency after changing the colors. This fixes all the issues I've had using pywal with st.