### PR TITLE
Add support for stylistic sets

### DIFF
--- a/config.h
+++ b/config.h
@@ -16,7 +16,7 @@ static int borderpx = 2;
  *
  * Example array for numuserfeats = 3: {"ss02", "ss08", "onum"}
  */
-static int numuserfeats = 0;
+static size_t numuserfeats = 0;
 static char *userfeats[] = {};
 
 /*

--- a/config.h
+++ b/config.h
@@ -10,6 +10,16 @@ static char *font2[] = { "JoyPixels:pixelsize=10:antialias=true:autohint=true" }
 static int borderpx = 2;
 
 /*
+ * Extra font features; generally used for stylistic sets
+ * Ensure numuserfeats is equal to the length of the userfeats array
+ * Note: value will always be set to 1; should be fine for stylistic sets
+ *
+ * Example array for numuserfeats = 3: {"ss02", "ss08", "onum"}
+ */
+static int numuserfeats = 0;
+static char *userfeats[] = {};
+
+/*
  * What program is execed by st depends of these precedence rules:
  * 1: program passed with -e
  * 2: utmp option

--- a/hb.c
+++ b/hb.c
@@ -125,6 +125,7 @@ hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoin
 	}
 
 	/* Prep user features for OpenType tags. */
+	errno = 0;
 	hb_feature_t *ufeats = calloc(numuserfeats, sizeof(hb_feature_t));
 	if (errno == ENOMEM)
 		ufeats = NULL;

--- a/hb.c
+++ b/hb.c
@@ -8,7 +8,7 @@
 
 #include "st.h"
 
-void hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoints, int start, int length, char **userfeats, int numuserfeats);
+void hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoints, int start, int length, char **userfeats, size_t numuserfeats);
 hb_font_t *hbfindfont(XftFont *match);
 
 typedef struct {
@@ -57,7 +57,7 @@ hbfindfont(XftFont *match)
 }
 
 void
-hbtransform(XftGlyphFontSpec *specs, const Glyph *glyphs, size_t len, int x, int y, char **userfeats, int numuserfeats)
+hbtransform(XftGlyphFontSpec *specs, const Glyph *glyphs, size_t len, int x, int y, char **userfeats, size_t numuserfeats)
 {
 	int start = 0, length = 1, gstart = 0;
 	hb_codepoint_t *codepoints = calloc(len, sizeof(hb_codepoint_t));
@@ -104,7 +104,7 @@ hbtransform(XftGlyphFontSpec *specs, const Glyph *glyphs, size_t len, int x, int
 }
 
 void
-hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoints, int start, int length, char **userfeats, int numuserfeats)
+hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoints, int start, int length, char **userfeats, size_t numuserfeats)
 {
 	hb_font_t *font = hbfindfont(xfont);
 	if (font == NULL)

--- a/hb.h
+++ b/hb.h
@@ -3,4 +3,4 @@
 #include <hb-ft.h>
 
 void hbunloadfonts();
-void hbtransform(XftGlyphFontSpec *, const Glyph *, size_t, int, int, char **, int);
+void hbtransform(XftGlyphFontSpec *, const Glyph *, size_t, int, int, char **, size_t);

--- a/hb.h
+++ b/hb.h
@@ -3,5 +3,4 @@
 #include <hb-ft.h>
 
 void hbunloadfonts();
-void hbtransform(XftGlyphFontSpec *, const Glyph *, size_t, int, int);
-
+void hbtransform(XftGlyphFontSpec *, const Glyph *, size_t, int, int, char **, int);

--- a/x.c
+++ b/x.c
@@ -1448,7 +1448,7 @@ xmakeglyphfontspecs(XftGlyphFontSpec *specs, const Glyph *glyphs, int len, int x
 	}
 
 	/* Harfbuzz transformation for ligatures. */
-	hbtransform(specs, glyphs, len, x, y);
+	hbtransform(specs, glyphs, len, x, y, userfeats, numuserfeats);
 
 	return numspecs;
 }


### PR DESCRIPTION
Other OTF tags may also work, though expanding the solution to support tags whose values aren't `1` is left to someone else to tackle.

Options are configurable via `config.h`, per the usual. Tested on my Void Linux desktop with Fira Code:

```c
numuserfeats = 6;
userfeats = {"ss01", "ss02", "ss03", "ss05", "ss06", "ss08"};
``` 

Also tested `numuserfeats = 0` with an empty array and all went well.