### PR TITLE
Fixed a small issue with the urlhandler.

### DIFF
--- a/st-urlhandler
+++ b/st-urlhandler
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-urlregex="(((http|https)://|www\\.)[a-zA-Z0-9.]*[:]?[a-zA-Z0-9./@$&%?$#=_-]*)|((magnet:\\?xt=urn:btih:)[a-zA-Z0-9]*)"
+urlregex="(((http|https)://|www\\.)[a-zA-Z0-9.]*[:]?[a-zA-Z0-9./@$&%?$\#=_~-]*)|((magnet:\\?xt=urn:btih:)[a-zA-Z0-9]*)"
 
 # First remove linebreaks and mutt sidebars:
 urls="$(sed 's/.*│//g' | tr -d '\n' |


### PR DESCRIPTION
Urls lile:

https://whatever.domain/~myprecious/usefull-blog.html
https://brb.imback.maybe/isit/blah#sure

Were not propery handled (everything after either '#' or '\~' were ignored).
Escaped '#' and added '\~' in the regex.

Signed-off-by: Pierguido Lambri <plambri@redhat.com>