### PR TITLE
Add support for additional alpha when the term-window is not focused

### DIFF
--- a/Xdefaults
+++ b/Xdefaults
@@ -1,6 +1,6 @@
 !! Transparency (0-1):
 st.alpha: 0.92
-st.alphaUnfocus: 0.62
+st.alphaOffset: 0.3
 
 !! Set a default font and font size as below:
 st.font: Monospace-11;

--- a/Xdefaults
+++ b/Xdefaults
@@ -1,5 +1,6 @@
 !! Transparency (0-1):
 st.alpha: 0.92
+st.alphaUnfocus: 0.62
 
 !! Set a default font and font size as below:
 st.font: Monospace-11;

--- a/config.h
+++ b/config.h
@@ -108,7 +108,8 @@ unsigned int tabspaces = 8;
 
 /* bg opacity */
 float alpha = 0.8;
-float alphaUnfocus = 0.8;
+float alphaOffset = 0.0;
+float alphaUnfocus;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
@@ -219,7 +220,7 @@ ResourcePref resources[] = {
 		{ "cwscale",      FLOAT,   &cwscale },
 		{ "chscale",      FLOAT,   &chscale },
 		{ "alpha",        FLOAT,   &alpha },
-		{ "alphaUnfocus", FLOAT,   &alphaUnfocus },
+		{ "alphaOffset",  FLOAT,   &alphaOffset },
 };
 
 /*

--- a/config.h
+++ b/config.h
@@ -108,6 +108,7 @@ unsigned int tabspaces = 8;
 
 /* bg opacity */
 float alpha = 0.8;
+float alphaUnfocus = 0.8;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
@@ -144,6 +145,7 @@ unsigned int defaultfg = 259;
 unsigned int defaultbg = 258;
 unsigned int defaultcs = 256;
 unsigned int defaultrcs = 257;
+unsigned int background = 258;
 
 /*
  * Default shape of cursor
@@ -217,6 +219,7 @@ ResourcePref resources[] = {
 		{ "cwscale",      FLOAT,   &cwscale },
 		{ "chscale",      FLOAT,   &chscale },
 		{ "alpha",        FLOAT,   &alpha },
+		{ "alphaUnfocus", FLOAT,   &alphaUnfocus },
 };
 
 /*

--- a/st.c
+++ b/st.c
@@ -201,7 +201,6 @@ static void tsetscroll(int, int);
 static void tswapscreen(void);
 static void tsetmode(int, int, int *, int);
 static int twrite(const char *, int, int);
-static void tfulldirt(void);
 static void tcontrolcode(uchar );
 static void tdectest(char );
 static void tdefutf8(char);

--- a/st.h
+++ b/st.h
@@ -82,6 +82,7 @@ typedef union {
 
 void die(const char *, ...);
 void redraw(void);
+void tfulldirt(void);
 void draw(void);
 
 void externalpipe(const Arg *);
@@ -138,4 +139,5 @@ extern unsigned int tabspaces;
 extern unsigned int defaultfg;
 extern unsigned int defaultbg;
 extern float alpha;
+extern float alphaUnfocus;
 extern const int boxdraw, boxdraw_bold, boxdraw_braille;

--- a/x.c
+++ b/x.c
@@ -182,6 +182,7 @@ static void xsetenv(void);
 static void xseturgency(int);
 static int evcol(XEvent *);
 static int evrow(XEvent *);
+static float clamp(float, float, float);
 
 static void expose(XEvent *);
 static void visibility(XEvent *);
@@ -319,10 +320,8 @@ changealpha(const Arg *arg)
 {
     if((alpha > 0 && arg->f < 0) || (alpha < 1 && arg->f > 0))
         alpha += arg->f;
-    if(alpha < 0)
-        alpha = 0;
-    if(alpha > 1)
-        alpha = 1;
+    alpha = clamp(alpha, 0.0, 1.0);
+    alphaUnfocus = clamp(alpha-alphaOffset, 0.0, 1.0);
 
     xloadcols();
     redraw();
@@ -379,6 +378,15 @@ evrow(XEvent *e)
 	int y = e->xbutton.y - borderpx;
 	LIMIT(y, 0, win.th - 1);
 	return y / win.ch;
+}
+
+float
+clamp(float value, float lower, float upper) {
+    if(value < lower)
+        return lower;
+    if(value > upper)
+        return upper;
+    return value;
 }
 
 void
@@ -2298,6 +2306,7 @@ run:
 	cols = MAX(cols, 1);
 	rows = MAX(rows, 1);
 	defaultbg = MAX(LEN(colorname), 256);
+	alphaUnfocus = alpha-alphaOffset;
 	tnew(cols, rows);
 	xinit(cols, rows);
 	xsetenv();


### PR DESCRIPTION
Solves #295

This is a somewhat adapted version of [suckless_alpha_focus](https://st.suckless.org/patches/alpha_focus_highlight/) for this build of st