### PR TITLE
Remove scroll info from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ features that make it literally the best terminal emulator ever:
 
 ## Bindings for
 
-+ scroll with `alt-↑/↓` or `alt-pageup/down` or `shift` while scrolling the
-  mouse (via [scroll](https://github.com/lukesmithxyz/scroll)).
++ **scrollback** with `alt-↑/↓` or `alt-pageup/down` or `shift` while scrolling the
+  mouse.
 + OR **vim-bindings**: scroll up/down in history with `alt-k` and `alt-j`.
   Faster with `alt-u`/`alt-d`.
 + **zoom/change font size**: same bindings as above, but holding down shift as
@@ -44,11 +44,8 @@ cd st
 sudo make install
 ```
 
-Note that [scroll](https://github.com/lukesmithxyz/scroll) is automatically
-pulled and installed when you make this build of st.
-
 Obviously, `make` is required to build. `fontconfig` is required for the
-default build, since it asks `fontconfig` for your system monospace font.  It
+default build, since it asks `fontconfig` for your system monospace font. It
 might be obvious, but `libX11` and `libXft` are required as well. Chances are,
 you have all of this installed already.
 


### PR DESCRIPTION
Outdated information. Currently scrollback patch is used instead.