### PR TITLE
Add stylistic sets / open type font feature

### DIFF
--- a/hb.c
+++ b/hb.c
@@ -18,8 +18,8 @@
  * latter to enable the (selected) font features.
  */
 
-//hb_feature_t features[] = { 0 };
-hb_feature_t features[] = { FEATURE('s','s','0','1'), FEATURE('s','s','0','2'), FEATURE('s','s','0','3'), FEATURE('s','s','0','5'), FEATURE('s','s','0','6'), FEATURE('s','s','0','7'), FEATURE('s','s','0','8'), FEATURE('z','e','r','o') };
+hb_feature_t features[] = { 0 };
+//hb_feature_t features[] = { FEATURE('s','s','0','1'), FEATURE('s','s','0','2'), FEATURE('s','s','0','3'), FEATURE('s','s','0','5'), FEATURE('s','s','0','6'), FEATURE('s','s','0','7'), FEATURE('s','s','0','8'), FEATURE('z','e','r','o') };
 
 void hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoints, int start, int length);
 hb_font_t *hbfindfont(XftFont *match);
@@ -73,7 +73,6 @@ void
 hbtransform(XftGlyphFontSpec *specs, const Glyph *glyphs, size_t len, int x, int y)
 {
 	int start = 0, length = 1, gstart = 0;
-	//hb_codepoint_t *codepoints = calloc(len, sizeof(hb_codepoint_t));
 	hb_codepoint_t *codepoints = calloc((unsigned int)len, sizeof(hb_codepoint_t));
 
 	for (int idx = 1, specidx = 1; idx < len; idx++) {
@@ -139,7 +138,6 @@ hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoin
 	}
 
 	/* Shape the segment. */
-	//hb_shape(font, buffer, NULL, 0);
 	hb_shape(font, buffer, features, sizeof(features));
 
 	/* Get new glyph info. */

--- a/hb.c
+++ b/hb.c
@@ -2,10 +2,24 @@
 #include <stdio.h>
 #include <math.h>
 #include <X11/Xft/Xft.h>
+#include <X11/cursorfont.h>
 #include <hb.h>
 #include <hb-ft.h>
 
 #include "st.h"
+
+#define FEATURE(c1,c2,c3,c4) { .tag = HB_TAG(c1,c2,c3,c4), .value = 1, .start = HB_FEATURE_GLOBAL_START, .end = HB_FEATURE_GLOBAL_END }
+
+/*
+ * Replace 0 with a list of font features, wrapped in FEATURE macro, e.g.
+ * FEATURE('c', 'a', 'l', 't'), FEATURE('d', 'l', 'i', 'g')
+ * 
+ * Uncomment either one of the 2 lines below. Uncomment the prior to disable (any) font features. Uncomment the 
+ * latter to enable the (selected) font features.
+ */
+
+//hb_feature_t features[] = { 0 };
+hb_feature_t features[] = { FEATURE('s','s','0','1'), FEATURE('s','s','0','2'), FEATURE('s','s','0','3'), FEATURE('s','s','0','5'), FEATURE('s','s','0','6'), FEATURE('s','s','0','7'), FEATURE('s','s','0','8'), FEATURE('z','e','r','o') };
 
 void hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoints, int start, int length);
 hb_font_t *hbfindfont(XftFont *match);
@@ -59,7 +73,8 @@ void
 hbtransform(XftGlyphFontSpec *specs, const Glyph *glyphs, size_t len, int x, int y)
 {
 	int start = 0, length = 1, gstart = 0;
-	hb_codepoint_t *codepoints = calloc(len, sizeof(hb_codepoint_t));
+	//hb_codepoint_t *codepoints = calloc(len, sizeof(hb_codepoint_t));
+	hb_codepoint_t *codepoints = calloc((unsigned int)len, sizeof(hb_codepoint_t));
 
 	for (int idx = 1, specidx = 1; idx < len; idx++) {
 		if (glyphs[idx].mode & ATTR_WDUMMY) {
@@ -124,7 +139,8 @@ hbtransformsegment(XftFont *xfont, const Glyph *string, hb_codepoint_t *codepoin
 	}
 
 	/* Shape the segment. */
-	hb_shape(font, buffer, NULL, 0);
+	//hb_shape(font, buffer, NULL, 0);
+	hb_shape(font, buffer, features, sizeof(features));
 
 	/* Get new glyph info. */
 	hb_glyph_info_t *info = hb_buffer_get_glyph_infos(buffer, NULL);


### PR DESCRIPTION
Using FEATURE macro and the corresponding method  from @cog1to latest patch.

Tested on **Fira Code** font.

Enable/disable the feature within this file, and then `sudo make install` as usual.