### PR TITLE
Install to ${HOME}/.local instead of /usr/local.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -4,7 +4,7 @@ VERSION = 0.8.4
 # Customize below to fit your system
 
 # paths
-PREFIX = /usr/local
+PREFIX = ${HOME}/.local
 MANPREFIX = $(PREFIX)/share/man
 
 X11INC = /usr/X11R6/include


### PR DESCRIPTION
Rationale:
- Private config.h settings do not spill to other users on multi-user systems
- No more sudo make install