### PR TITLE
Use `dmenuhandler` in `st-urlhandler`

### DIFF
--- a/st-urlhandler
+++ b/st-urlhandler
@@ -5,15 +5,12 @@ urlregex="(((http|https|gopher|gemini|ftp|ftps|git)://|www\\.)[a-zA-Z0-9.]*[:;a-
 urls="$(sed 's/.*│//g' | tr -d '\n' | # First remove linebreaks and mutt sidebars:
 	grep -aEo "$urlregex" | # grep only urls as defined above.
 	uniq | # Ignore neighboring duplicates.
-	sed "s/\(\.\|,\|;\|\!\\|\?\)$//;
-	s/^www./http:\/\/www\./")" # xdg-open will not detect url without http
+	sed "s/\(\.\|,\|;\|\!\\|\?\)$//")"
 
 [ -z "$urls" ] && exit 1
 
-while getopts "hoc" o; do case "${o}" in
-	h) printf "Optional arguments for custom use:\\n  -c: copy\\n  -o: xdg-open\\n  -h: Show this message\\n" && exit 1 ;;
-	o) chosen="$(echo "$urls" | dmenu -i -p 'Follow which url?' -l 10)"
-	setsid xdg-open "$chosen" >/dev/null 2>&1 & ;;
-	c) echo "$urls" | dmenu -i -p 'Copy which url?' -l 10 | tr -d '\n' | xclip -selection clipboard ;;
-	*) printf "Invalid option: -%s\\n" "$OPTARG" && exit 1 ;;
-esac done
+urlchoice="$(echo "$urls" | dmenu -i -l 10 -p 'Select a URL')"
+
+[ -z "$urlchoice" ] && exit 1
+
+dmenuhandler "$urlchoice"


### PR DESCRIPTION
## Changes
- Let `dmenuhandler` take care of the actions that may be performed on the URL selected, instead of relying on `xdg-open`.
- Removed `sed` substitution that needed to be performed for `xdg-open`.

## Intention
Keep as much of the logic that deals with opening URL (and other actions) in one place, `dmenuhandler`.

## Drawback
People will have to have the `dmenuhandler` script, which comes from [voidrice](https://github.com/LukeSmithxyz/voidrice/blob/master/.local/bin/dmenuhandler). This isn't a major problem, but something to be aware of. 