### PR TITLE
Fix "Did not detect DSR response"

### DIFF
--- a/st.c
+++ b/st.c
@@ -1852,11 +1852,18 @@ csihandle(void)
 	case 'm': /* SGR -- Terminal attribute (color) */
 		tsetattr(csiescseq.arg, csiescseq.narg);
 		break;
-	case 'n': /* DSR – Device Status Report (cursor position) */
-		if (csiescseq.arg[0] == 6) {
+	case 'n': /* DSR -- Device Status Report */
+		switch (csiescseq.arg[0]) {
+		case 5: /* Status Report "OK" `0n` */
+			ttywrite("\033[0n", sizeof("\033[0n") - 1, 0);
+			break;
+		case 6: /* Report Cursor Position (CPR) "<row>;<column>R" */
 			len = snprintf(buf, sizeof(buf), "\033[%i;%iR",
 					term.c.y+1, term.c.x+1);
 			ttywrite(buf, len, 0);
+			break;
+		default:
+			goto unknown;
 		}
 		break;
 	case 'r': /* DECSTBM -- Set Scrolling Region */


### PR DESCRIPTION
Neovim's v0.12 upgrade causes the following error: https://github.com/neovim/neovim/discussions/38151 when using Luke's st fork.

Applying the following patch fixes this error: https://git.suckless.org/st/commit/f17abd25b376c292f783062ecf821453eaa9cc4c.html#h0-0-3